### PR TITLE
Added support for Bitmap string 

### DIFF
--- a/src/ofxOscilloscope.cpp
+++ b/src/ofxOscilloscope.cpp
@@ -985,8 +985,7 @@ void ofxOscilloscope::plot(){
 
 	
 	string yVal;
-	ofRectangle yValBox;
-	ofBitmapFont bitmapFont; 
+	ofRectangle yValBox; 
 
 	if (_axesFont.isLoaded()) {
 
@@ -1005,6 +1004,7 @@ void ofxOscilloscope::plot(){
 	}
 	else
 	{
+		ofBitmapFont bitmapFont;
 		yVal = ofToString(-getYOffset() / getYScale());
         yValBox = bitmapFont.getBoundingBox(yVal,0,0);
         ofDrawBitmapString(yVal, yValX - yValBox.getRight(), yValY + yValBox.getHeight() / 2);

--- a/src/ofxOscilloscope.cpp
+++ b/src/ofxOscilloscope.cpp
@@ -986,6 +986,7 @@ void ofxOscilloscope::plot(){
 	
 	string yVal;
 	ofRectangle yValBox;
+	ofBitmapFont bitmapFont; 
 
 	if (_axesFont.isLoaded()) {
 
@@ -1004,7 +1005,17 @@ void ofxOscilloscope::plot(){
 	}
 	else
 	{
-		// ToDo: write ofDrawBitmapString alternative
+		yVal = ofToString(-getYOffset() / getYScale());
+        yValBox = bitmapFont.getBoundingBox(yVal,0,0);
+        ofDrawBitmapString(yVal, yValX - yValBox.getRight(), yValY + yValBox.getHeight() / 2);
+        
+        yVal = ofToString((-getYOffset() + ofGetWindowHeight() / 2) / getYScale());
+        yValBox = bitmapFont.getBoundingBox(yVal,0,0);
+        ofDrawBitmapString(yVal, yValX - yValBox.getRight(), _min.y - yValBox.getTop() + yLabelPadding);
+        
+        yVal = ofToString((-getYOffset() - ofGetWindowHeight() / 2) / getYScale());
+        yValBox = bitmapFont.getBoundingBox(yVal,0,0);
+        ofDrawBitmapString(yVal,  yValX - yValBox.getRight(), _max.y - yLabelPadding);
 	}
 
 


### PR DESCRIPTION
Fix:
1. y-axis labels are not displayed with bitmap strings in absence of font files or if font files are not loaded.