### PR TITLE
Introducing compatibility for openframeworks 11

### DIFF
--- a/src/ofxOscilloscope.h
+++ b/src/ofxOscilloscope.h
@@ -17,8 +17,9 @@
 #include <vector>
 #include <algorithm>
 
-#define OFX_OSCILLOSCOPE_VERSION_MAJOR 0
-#define OFX_OSCILLOSCOPE_VERSION_MINOR 11 // something about versioning
+#define OFX_SUPPORT_VERSION_MAJOR_0 0
+#define OFX_SUPPORT_VERSION_MINOR_9 9
+#define OFX_SUPPORT_VERSION_MINOR_10 10
 
 /*-------------------------------------------------
 * ofxScopePlot
@@ -216,12 +217,12 @@ public:
 
 	// Constructors
 	ofxMultiScope();
-	#if (OF_VERSION_MINOR == OFX_OSCILLOSCOPE_VERSION_MINOR) 
+	#if (OF_VERSION_MAJOR > OFX_SUPPORT_VERSION_MAJOR_0 || OF_VERSION_MINOR >= OFX_SUPPORT_VERSION_MINOR_10)
 		ofxMultiScope(int numScopes, ofRectangle plotArea = ofRectangle(glm::vec2(0, 0), ofGetWindowSize()),
 			ofTrueTypeFont legendFont = ofTrueTypeFont(), int legendWidth = 100,
 			ofColor outlineColor = ofColor(200, 200, 200), ofColor zeroLineColor = ofColor(140, 140, 140),
 			ofColor backgroundColor = ofColor(0., 0., 0., 0.));
-	#else 
+	#elif (OF_VERSION_MINOR <= OFX_SUPPORT_VERSION_MINOR_9)
 	// for OFX0.9.8, ofRectangle has cinstructor ofPoint
 		ofxMultiScope(int numScopes, ofRectangle plotArea = ofRectangle(ofPoint(0, 0), ofGetWindowSize()),
 			ofTrueTypeFont legendFont = ofTrueTypeFont(), int legendWidth = 100,

--- a/src/ofxOscilloscope.h
+++ b/src/ofxOscilloscope.h
@@ -17,6 +17,8 @@
 #include <vector>
 #include <algorithm>
 
+#define OFX_OSCILLOSCOPE_VERSION_MAJOR 0
+#define OFX_OSCILLOSCOPE_VERSION_MINOR 11 // something about versioning
 
 /*-------------------------------------------------
 * ofxScopePlot
@@ -214,10 +216,18 @@ public:
 
 	// Constructors
 	ofxMultiScope();
-	ofxMultiScope(int numScopes, ofRectangle plotArea=ofRectangle(glm::vec2(0,0), ofGetWindowSize()), 
-		ofTrueTypeFont legendFont=ofTrueTypeFont(), int legendWidth=100,
-		ofColor outlineColor=ofColor(200,200,200), ofColor zeroLineColor=ofColor(140,140,140),
-		ofColor backgroundColor=ofColor(0.,0.,0.,0.));
+	#if (OF_VERSION_MINOR == OFX_OSCILLOSCOPE_VERSION_MINOR) 
+		ofxMultiScope(int numScopes, ofRectangle plotArea = ofRectangle(glm::vec2(0, 0), ofGetWindowSize()),
+			ofTrueTypeFont legendFont = ofTrueTypeFont(), int legendWidth = 100,
+			ofColor outlineColor = ofColor(200, 200, 200), ofColor zeroLineColor = ofColor(140, 140, 140),
+			ofColor backgroundColor = ofColor(0., 0., 0., 0.));
+	#else 
+	// for OFX0.9.8, ofRectangle has cinstructor ofPoint
+		ofxMultiScope(int numScopes, ofRectangle plotArea = ofRectangle(ofPoint(0, 0), ofGetWindowSize()),
+			ofTrueTypeFont legendFont = ofTrueTypeFont(), int legendWidth = 100,
+			ofColor outlineColor = ofColor(200, 200, 200), ofColor zeroLineColor = ofColor(140, 140, 140),
+			ofColor backgroundColor = ofColor(0., 0., 0., 0.));
+	#endif
 	ofxMultiScope(int numScopes, ofPoint min=ofPoint(0,0), ofPoint max=ofGetWindowSize(), 
 		ofTrueTypeFont legendFont=ofTrueTypeFont(), int legendWidth=100,
 		ofColor outlineColor=ofColor(200,200,200), ofColor zeroLineColor=ofColor(140,140,140),

--- a/src/ofxOscilloscope.h
+++ b/src/ofxOscilloscope.h
@@ -214,7 +214,7 @@ public:
 
 	// Constructors
 	ofxMultiScope();
-	ofxMultiScope(int numScopes, ofRectangle plotArea=ofRectangle(ofPoint(0,0), ofGetWindowSize()), 
+	ofxMultiScope(int numScopes, ofRectangle plotArea=ofRectangle(glm::vec2(0,0), ofGetWindowSize()), 
 		ofTrueTypeFont legendFont=ofTrueTypeFont(), int legendWidth=100,
 		ofColor outlineColor=ofColor(200,200,200), ofColor zeroLineColor=ofColor(140,140,140),
 		ofColor backgroundColor=ofColor(0.,0.,0.,0.));


### PR DESCRIPTION
## Improvements
- Added a version check to invoke constructor
  - OFX 11 deprecated ofRectangle contructor that takes ofPoint as in Input. [new ofRectangle contructors](https://openframeworks.cc///documentation/types/ofRectangle/)
  - Introduced a OF version check to invoke different constructors depending on the OFX version 