### PR TITLE
minor change to enable dynamic plot update in oscilloscope

### DIFF
--- a/src/ofxOscilloscope.cpp
+++ b/src/ofxOscilloscope.cpp
@@ -63,7 +63,7 @@ void ofxScopePlot::setup(float timeWindow, float sampFreq, std::vector<ofColor> 
 		_pointsPerWin = floor(_timeWindow * sampFreq); //(sec)
 		_sampFreq = sampFreq;
 		_nVariables = variableColors.size();
-
+		_buffer.clear();
 		for (int i=0; i<_nVariables; i++) {
 			_buffer.push_back(std::vector<float>(_pointsPerWin, 0.));
 		}


### PR DESCRIPTION
# Description
- clears plot buffers on setup.

# Reason
- The usage in EmotiBitOscilloscope has changed.
- EmotiBit oscilloscope [updates plots](https://github.com/EmotiBit/ofxEmotiBit/blob/8e693419d58e957a3b6269b1bcdcca1020481b80/EmotiBitOscilloscope/src/ofApp.cpp#L84) based on detected data streams.
- When `scope.setup()` is called, if original plot buffers are not cleared, the buffers keep increasing in size, thus causing vector out of bounds.

# Explanation for fix
- every time setup is called, if the original object buffers are cleared, successive calls maintain the most updated buffer structure.
- Since setup is called during setting up scopes, clearing buffers should not cause breakage in usage.
  - **Caution**: If setup is being called to `UPDATE`(not the intended use), clearing buffers might cause a code break.